### PR TITLE
Phase 7: PDF Preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ crossterm = "0.28"
 syntect = "5"
 ratatui-image = "1"
 image = "0.25"
+pdfium-render = "0.8"
 
 [dev-dependencies]
 tempfile = "3"
+printpdf = "0.7"


### PR DESCRIPTION
## Summary

Implements PDF preview functionality using pdfium-render.

### Changes

- **PDF Rendering**: Added `render_pdf_first_page()` to render the first page of a PDF to an image
- **Pdfium Detection**: Added `is_pdfium_available()` helper to safely check if the pdfium library is installed
- **Error Handling**: Properly handles cases where pdfium library is not available or PDFs are corrupted/password-protected
- **ASCII Art Preview**: Renders PDF pages as ASCII art in the terminal, consistent with image previews

### Technical Details

- Uses `std::panic::catch_unwind` to safely handle pdfium initialization failures
- Tests skip gracefully when pdfium library is not installed
- Renders PDFs at 1024x1024 max resolution before converting to ASCII

### Testing

- All 72 tests pass
- `cargo fmt` clean
- `cargo clippy` clean

### Notes

Requires libpdfium to be installed for PDF preview functionality. Without it, PDF previews show an error message explaining how to enable the feature.